### PR TITLE
Let bikeshed know about the repository

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4,7 +4,7 @@ Title: CommonType
 Shortname: commontype
 Level: 1
 Status: LD
-URL: http://www.commontype.org/
+URL: https://www.commontype.org/
 Editor: Simon Cozens, Corvel Software, simon@simon-cozens.org
 Repository: commontype-standard/commontype
 Markup Shorthands: markdown yes

--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,7 @@ Level: 1
 Status: LD
 URL: http://www.commontype.org/
 Editor: Simon Cozens, Corvel Software, simon@simon-cozens.org
-Issue Tracking: GitHub https://github.com/commontype-standard/commontype/issues
+Repository: commontype-standard/commontype
 Markup Shorthands: markdown yes
 Abstract: CommonType describes and annotates the file format and processing requirements for font files.
 </pre>


### PR DESCRIPTION
Instead of directly linking to the issues
(which ends up generating a double link in the output,
as bikeshed also guesses we're operating from github),
directly tell bikeshed which repo we're operating from.

Syntax documented here:
https://tabatkins.github.io/bikeshed/#metadata-repository

That will let it generate the "Issue Tracking" link correctly,
as well as enable the short syntax for remote issues
(https://tabatkins.github.io/bikeshed/#remote-issues).